### PR TITLE
Fix `export` to be `export default` in src/position/bk.js.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "chai": "^3.5.0",
     "eslint": "^3.4.0",
     "eslint-config-standard": "^6.0.0",
-    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.0",
-    "istanbul": "^0.4.3",
+    "istanbul": "^0.4.5",
     "mocha": "^3.0.0"
   },
   "repository": {

--- a/src/position/bk.js
+++ b/src/position/bk.js
@@ -391,8 +391,7 @@ export function width (g, v) {
   return g.node(v).width
 }
 
-export {
-  addConflict,
+export default {
   alignCoordinates,
   balance,
   buildBlockGraph,


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

Fix `export` to be `export default` in `src/position/bk.js`.
