### PR TITLE
don't use debug timings unless debugTiming == true

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -412,10 +412,10 @@ function canonicalize (attrs) {
 
 export default function layout (g, opts) {
   var timeFn = opts && opts.debugTiming ? time : notime
-  time('layout', function () {
-    var layoutGraph = time('  buildLayoutGraph',
+  timeFn('layout', function () {
+    var layoutGraph = timeFn('  buildLayoutGraph',
                                function () { return buildLayoutGraph(g) })
-    time('  runLayout', function () { runLayout(layoutGraph, timeFn) })
-    time('  updateInputGraph', function () { updateInputGraph(g, layoutGraph) })
+    timeFn('  runLayout', function () { runLayout(layoutGraph, timeFn) })
+    timeFn('  updateInputGraph', function () { updateInputGraph(g, layoutGraph) })
   })
 }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
don't use debug timings unless debugTiming == true 
