### PR TITLE
delete ignore /src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,3 @@ dependency-snapshot.json
 CHANGELOG.md
 /node_modules
 /tests
-/src


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Removed** /src in /.npmignore
