### PR TITLE
Use transpiled files in distribution

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,13 +20,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-import {debugOrdering} from './src/debug'
+import {debugOrdering} from './lib/debug'
 
 export var debug = {
   debugOrdering
 }
 
-export {default as layout} from './src/layout'
+export {default as layout} from './lib/layout'
 
 import {
   addBorderNode,
@@ -43,7 +43,7 @@ import {
   simplify,
   successorWeights,
   time
-} from './src/util'
+} from './lib/util'
 
 export var util = {
   addBorderNode,


### PR DESCRIPTION
The current distribution references the source files rather than the transpiled files. This means that importing this module into a non-transpiled ES5 project breaks it completely.

**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

We now distribute ES5 code rather than the ESNext source, so that this library can be used as is instead of requiring a transpiler.